### PR TITLE
Release: 1.2.5 - Require WooCommerce to be active to activate

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -74,7 +74,7 @@ Please visit our [Knowledge Base](https://barn2.com/kb-categories/custom-add-to-
 == Changelog ==
 
 = 1.2.5 =
-Release date nn Month 2024
+Release date 22 May 2024
 
 * Fix: Ensure the plugin does not activate if WooCommerce is not active
 

--- a/readme.txt
+++ b/readme.txt
@@ -64,7 +64,7 @@ The plugin inherits the styles from your theme. This means that the button size 
 
 = Can I choose a different icon, change the size, change colors, etc? =
 
-We've kept the plugin deliberately simple and it's not currently possible to make other changes such as different icons. Please use the support tab or our <a href="https://kestrelwp.slack.com/archives/C06MAPUJ78D/p1716305249255949?thread_ts=1716302269.299999&cid=C06MAPUJ78D">feature request form</a> if there's anything else you'd like the plugin to do. We will add new features if there is enough demand.
+We've kept the plugin deliberately simple and it's not currently possible to make other changes such as different icons. Please use the support tab or our <a href="https://kestrelwp.com/support">feature request form</a> if there's anything else you'd like the plugin to do. We will add new features if there is enough demand.
 
 
 == Changelog ==

--- a/readme.txt
+++ b/readme.txt
@@ -39,8 +39,6 @@ WooCommerce Custom Add to Cart Button is fully compatible with other Kestrel plu
 * [Variation Prices](https://kestrelwp.com/product/variation-prices-woocommerce/?utm_source=wporg&utm_medium=freeplugin&utm_campaign=freepluginwporg&utm_content=atoc-free) - Improve the display of variation prices in your WooCommerce store.
 * [Product Sample](https://kestrelwp.com/product/product-sample-woocommerce/?utm_source=wporg&utm_medium=freeplugin&utm_campaign=freepluginwporg&utm_content=atoc-free) - Let customers “try before they buy” with free or paid product samples.
 
-You can view the full [plugin documentation](https://barn2.com/kb-categories/custom-add-to-cart-kb/?utm=content&utm_source=wporg&utm_medium=freeplugin&utm_campaign=freepluginwporg&utm_content=atoc-free) in our Knowledge Base.
-
 == Installation ==
 
 1. Install via the Plugins screen in your WordPress dashboard, or download the ZIP, extract it, and upload to the `/wp-content/plugins/` directory.
@@ -66,10 +64,8 @@ The plugin inherits the styles from your theme. This means that the button size 
 
 = Can I choose a different icon, change the size, change colors, etc? =
 
-We've kept the plugin deliberately simple and it's not currently possible to make other changes such as different icons. Please use the support tab or our <a href="https://barn2.com/plugin-feature-request/?utm=content&utm_source=wporg&utm_medium=freeplugin&utm_campaign=freepluginwporg&utm_content=atoc-free">feature request form</a> if there's anything else you'd like the plugin to do. We will add new features if there is enough demand.
+We've kept the plugin deliberately simple and it's not currently possible to make other changes such as different icons. Please use the support tab or our <a href="https://kestrelwp.slack.com/archives/C06MAPUJ78D/p1716305249255949?thread_ts=1716302269.299999&cid=C06MAPUJ78D">feature request form</a> if there's anything else you'd like the plugin to do. We will add new features if there is enough demand.
 
-= Where can I find the documentation? =
-Please visit our [Knowledge Base](https://barn2.com/kb-categories/custom-add-to-cart-kb?utm=content&utm_source=wporg&utm_medium=freeplugin&utm_campaign=freepluginwporg&utm_content=atoc-free/).
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Donate link: https://kestrelwp.com
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.2.4
+Stable tag: 1.2.5
 License: GNU General Public License v3.0
 License URI: https://www.gnu.org/licenses/gpl.html
 
@@ -72,6 +72,11 @@ We've kept the plugin deliberately simple and it's not currently possible to mak
 Please visit our [Knowledge Base](https://barn2.com/kb-categories/custom-add-to-cart-kb?utm=content&utm_source=wporg&utm_medium=freeplugin&utm_campaign=freepluginwporg&utm_content=atoc-free/).
 
 == Changelog ==
+
+= 1.2.5 =
+Release date nn Month 2024
+
+* Fix: Ensure the plugin does not activate if WooCommerce is not active
 
 = 1.2.4 =
 Release date 27 March 2024

--- a/woo-custom-add-to-cart-button.php
+++ b/woo-custom-add-to-cart-button.php
@@ -11,7 +11,7 @@
  * Plugin Name:     WooCommerce Custom Add To Cart Button
  * Plugin URI:      https://kestrelwp.com/product/custom-add-to-cart-button-for-woocommerce/
  * Description:     Customize the Add to Cart buttons in WooCommerce by changing the text or adding a cart icon.
- * Version:         1.2.4
+ * Version:         1.2.5
  * Author:          Kestrel
  * Author URI:      https://kestrelwp.com
  * Text Domain:     woo-custom-add-to-cart-button
@@ -20,6 +20,7 @@
  * Tested up to: 6.5
  * Requires PHP: 7.4
  *
+ * Requires Plugins: woocommerce
  * WC requires at least: 6.5
  * WC tested up to: 8.7
  *
@@ -34,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-const PLUGIN_VERSION = '1.2.4';
+const PLUGIN_VERSION = '1.2.5';
 const PLUGIN_FILE    = __FILE__;
 
 // Autoloader.


### PR DESCRIPTION
## Summary

Barn Plugins do not seem having checks in places as to whether WC is active before they initialize. This could result in errors if WC functions and classes are called directly. 

We want to avoid this possibility and implement a simple sanity check similar to what we had in SV plugins plugin loader class. ~~This PR doesn't implement the whole logic or notices... For those we can wait to have a new Framework and more specific WP/WC min requirements to be more informative.~~ Initially I wanted to move some loader logic to `plugins_loaded` but for [these reasons](https://kestrelwp.slack.com/archives/C06MAPUJ78D/p1716183701680559?thread_ts=1716175676.208109&cid=C06MAPUJ78D) it's not as straightforward until we start making more changes (yes, this is a free plugin and the licensing package doesn't apply but I decided to be consistent with the other Barn plugin PRs I've been pushing out today). However, we can add the `Requires Plugins` tag introduced by WP 6.5: https://make.wordpress.org/core/2024/03/05/introducing-plugin-dependencies-in-wordpress-6-5/

![Screenshot 2024-05-20 at 15 16 10](https://github.com/kestrelwp/woo-custom-add-to-cart-button/assets/1227930/049c968f-b448-4170-9d07-e15b71884363)
![Screenshot 2024-05-20 at 15 16 49](https://github.com/kestrelwp/woo-custom-add-to-cart-button/assets/1227930/76c1e29a-19fd-4397-ad64-4971baecc6d0)


### QA

1. Deactivate WooCommerce
1. Activate the plugin
    - [ ] If you are running WP 6.5+, you shouldn't be able to activate it at all
    - [ ] If you manage to activate the plugin (eg via WP CLI), if should display a notice as in the screenshots above and the plugin should do nothing at all
1. Activate WooCommerce
    - [ ] You are able to activate the plugin
    - [ ] The plugin works as expected
1. Deactivate WooCommerce
    - [ ] In WP 6.5+ you shouldn't be able to deactivate it (can be done via WP CLI)
    - [ ] The plugin stays active but does nothing and shows a notice as above


### Related Story: [SC-2763](https://app.shortcut.com/kestrel/story/2763/barn2-plugins-fatal-if-activated-when-woo-is-not-active)

## Before Merge

- [ ] Check that this conversation is resolved https://kestrelwp.slack.com/archives/C06MAPUJ78D/p1716175676208109